### PR TITLE
Add user special term feature

### DIFF
--- a/src/Model/HandleSearch/DocDataHolders/DocRankData.java
+++ b/src/Model/HandleSearch/DocDataHolders/DocRankData.java
@@ -25,6 +25,7 @@ public class DocRankData {
 
     private ArrayList<Pair<Term, Integer>> docHeaderStrings;
     private String docDate;
+    private boolean hasSpecialTerm = false;
 
      public DocRankData(String docNo){
          this.docNo = docNo;
@@ -147,5 +148,13 @@ public class DocRankData {
 
     public String getDocNo() {
         return docNo;
+    }
+
+    public boolean hasSpecialTerm() {
+        return hasSpecialTerm;
+    }
+
+    public void setHasSpecialTerm(boolean hasSpecialTerm) {
+        this.hasSpecialTerm = hasSpecialTerm;
     }
 }

--- a/src/Model/HandleSearch/Ranker.java
+++ b/src/Model/HandleSearch/Ranker.java
@@ -94,6 +94,8 @@ public class Ranker {
         }
         if(QueryContainsMaxTerm(docRankData))
             output += 0.1 * output;
+        if(docRankData.hasSpecialTerm())
+            output += 0.15 * output;
         return output;
     }
 

--- a/src/Model/HandleSearch/Searcher.java
+++ b/src/Model/HandleSearch/Searcher.java
@@ -11,6 +11,7 @@ import Model.TermsAndDocs.Terms.CapsTerm;
 import Model.TermsAndDocs.Terms.RegularTerm;
 import Model.TermsAndDocs.Terms.Term;
 import Model.TermsAndDocs.Terms.TermBuilder;
+import Model.TermsAndDocs.Terms.UserSpecialTerm;
 import com.medallia.word2vec.Word2VecModel;
 import Model.HandleSearch.datamuse.DatamuseQuery;
 import Model.HandleSearch.datamuse.JSONParse;
@@ -43,10 +44,11 @@ public class Searcher {
     private boolean withEntities;
     private ArrayList<String> queries;
     private boolean isOnline;
+    private String specialTerm;
 
 
     public Searcher(boolean isSemantic, boolean isStemm, Dictionary dictionary, HashSet<String> stopWords
-            , ArrayList<String> queries, boolean withEntities, boolean online) {
+            , ArrayList<String> queries, boolean withEntities, boolean online, String specialTerm) {
         this.isSemantic = isSemantic;
         this.isStemm = isStemm;
         this.dictionary = dictionary;
@@ -54,6 +56,7 @@ public class Searcher {
         this.withEntities = withEntities;
         this.queries = queries;
         this.isOnline=online;
+        this.specialTerm = specialTerm;
     }
 
     /**
@@ -69,9 +72,20 @@ public class Searcher {
         ArrayList<DocumentDataToView> [] allAnswers = new ArrayList[queries.size()];
         ArrayList<TermDocPair> []allQueryTerms = new ArrayList[allAnswers.length];
         ArrayList<TermDocPair> []allSemanticTerms = new ArrayList[allAnswers.length];
+        ArrayList<TermDocPair> specialList = null;
+        HashMap<Term, String> postDataForSpecial = null;
         for(int i = 0; i < allAnswers.length; i++){
             allQueryTerms[i] = new ArrayList<>();
             allSemanticTerms[i] = new ArrayList<>();
+        }
+
+        if(specialTerm != null && !specialTerm.equals("")){
+            ArrayList<String> sp = new ArrayList<>();
+            sp.add(specialTerm);
+            specialList = parseQueryAndHeader(sp,0);
+            ArrayList<TermDocPair>[] spArr = new ArrayList[1];
+            spArr[0] = specialList;
+            postDataForSpecial = getPostData(spArr);
         }
 
         for (int k = 0; k < allAnswers.length; k++) {
@@ -100,6 +114,10 @@ public class Searcher {
             HashMap<String, DocRankData> hashChecker = new HashMap<>();
             getDocsData(queryTermPostingData, hashChecker, 0);
             getDocsData(semanticTermPostingData, hashChecker, 1);
+            if(postDataForSpecial != null){
+                ArrayList<Pair<TermDocPair, String>> specialPostingData = findPostDataInHash(specialList, postDataForSpecial);
+                getDocsData(specialPostingData, hashChecker, 2);
+            }
 
             //ranking every relevant doc
             ArrayList<Pair<String, Double>> keepScores = new ArrayList<>();
@@ -213,9 +231,13 @@ public class Searcher {
                 if(recognizer == 0){
                     currentDocData.addQueryWordData(new Pair<>(currentTerm, appearInQuery), termTf, termDf);
                 }
-                else{
+                else if(recognizer == 1){
                     if(currentDocData != null)
                         currentDocData.addSimilarQueryWordData(new Pair<>(currentTerm, appearInQuery), termTf, termDf);
+                }
+                else if(recognizer == 2){
+                    if(currentDocData != null)
+                        currentDocData.setHasSpecialTerm(true);
                 }
             }
         }

--- a/src/Model/ProgramStarter.java
+++ b/src/Model/ProgramStarter.java
@@ -187,7 +187,7 @@ public class ProgramStarter {
     }
 
     @SuppressWarnings("Duplicates")
-    public static void runQueriesFromFile(String path, boolean similarWords, boolean writeResultToFileCheckBoxIsSelected, boolean showEntitiesCheckBoxIsSelected, boolean stemCheckBoxIsSelected, boolean onlineSemanticIsSelected, String resultFileText, String resultFileName, String inputPath, boolean showDatesIsSelected) {
+    public static void runQueriesFromFile(String path, boolean similarWords, boolean writeResultToFileCheckBoxIsSelected, boolean showEntitiesCheckBoxIsSelected, boolean stemCheckBoxIsSelected, boolean onlineSemanticIsSelected, String resultFileText, String resultFileName, String inputPath, boolean showDatesIsSelected, String specialTerm) {
         long time1 = System.currentTimeMillis();
         try {
             HashMap<String, String> queriesHash = QueryFileUtil.extractQueries(path);
@@ -213,7 +213,7 @@ public class ProgramStarter {
                 DocumentFileObject documentFileObject = DocumentFileObject.getInstance();
                 documentFileObject.setInstance(documentFileHandler.extractDocsData(generateDocsFiles(stemCheckBoxIsSelected, GUI.outputPathTextField.getText())));
             }
-            Searcher searcher = new Searcher(similarWords, stemIsSelected, dictionary, generateStopWords(inputPath), queries, entities, onlineIsSelected);
+            Searcher searcher = new Searcher(similarWords, stemIsSelected, dictionary, generateStopWords(inputPath), queries, entities, onlineIsSelected, specialTerm);
             ArrayList<QueryIDDocDataToView> datas = new ArrayList<>();
             ArrayList<DocumentDataToView>[] queryAnswers = searcher.search();
             for (int i = 0; i < queryAnswers.length; i++) {
@@ -256,7 +256,7 @@ public class ProgramStarter {
     }
 
     @SuppressWarnings("Duplicates")
-    public static void runSingleQuery(String query, boolean similarWords, boolean writeResultToFileIsSelected, boolean showEntitiesIsSelected, boolean stemCheckBoxIsSelected, boolean onlineSemanticIsSelected, String resultFileText, String resultFileName, boolean showDatesIsSelected, String inputPath) {
+    public static void runSingleQuery(String query, boolean similarWords, boolean writeResultToFileIsSelected, boolean showEntitiesIsSelected, boolean stemCheckBoxIsSelected, boolean onlineSemanticIsSelected, String resultFileText, String resultFileName, boolean showDatesIsSelected, String inputPath, String specialTerm) {
         boolean writeToFile = writeResultToFileIsSelected;
         boolean entities = showEntitiesIsSelected;
         if (dictionary == null || dictionary.dictionaryTable.size() == 0) {
@@ -278,7 +278,7 @@ public class ProgramStarter {
         }
         ArrayList<String> queryList = new ArrayList<>();
         queryList.add(query);
-        Searcher searcher = new Searcher(similarWords, stemCheckBoxIsSelected, dictionary, generateStopWords(inputPath), queryList, entities, onlineSemanticIsSelected);
+        Searcher searcher = new Searcher(similarWords, stemCheckBoxIsSelected, dictionary, generateStopWords(inputPath), queryList, entities, onlineSemanticIsSelected, specialTerm);
         ArrayList<DocumentDataToView>[] answer = searcher.search();
         showResultsWithoutIds(answer[0], showDatesIsSelected, showEntitiesIsSelected);
         if (writeToFile) {

--- a/src/Model/TermsAndDocs/Terms/TermBuilder.java
+++ b/src/Model/TermsAndDocs/Terms/TermBuilder.java
@@ -45,6 +45,9 @@ public class TermBuilder {
             case ("MeasurementTerm"):
                 output = new MeasurementTerm(data);
                 break;
+            case ("UserSpecialTerm"):
+                output = new UserSpecialTerm(data);
+                break;
             default:
                 output = null;
         }

--- a/src/Model/TermsAndDocs/Terms/UserSpecialTerm.java
+++ b/src/Model/TermsAndDocs/Terms/UserSpecialTerm.java
@@ -1,0 +1,12 @@
+package Model.TermsAndDocs.Terms;
+
+public class UserSpecialTerm extends Term {
+    public UserSpecialTerm(String data) {
+        super(data);
+    }
+
+    @Override
+    public String getType() {
+        return "UserSpecialTerm";
+    }
+}

--- a/src/View/GUI.java
+++ b/src/View/GUI.java
@@ -53,6 +53,7 @@ public class GUI extends Application implements EventHandler<ActionEvent> {
     public static TextField outputPathTextField;
     //part 2
     TextField singleQueryTextField;
+    TextField specialTermTextField;
     TextField queriesFilePathTextFiled;
     TextField resultFileTextField;
 
@@ -114,6 +115,8 @@ public class GUI extends Application implements EventHandler<ActionEvent> {
         singleQueryTextField = new TextField();
         singleQueryTextField.setText("Insert your query here");
         singleQueryTextField.setPrefSize(315, 40);
+        specialTermTextField = new TextField();
+        specialTermTextField.setPromptText("Special term");
         queriesFilePathTextFiled = new TextField();
         queriesFilePathTextFiled.setText("Or choose a file...");
         resultFileTextField = new TextField();
@@ -202,6 +205,9 @@ public class GUI extends Application implements EventHandler<ActionEvent> {
         resultFileHBox = new HBox(resultFileTextField, resultsFilePathBrowseButton, writeResultsToFileCheckBox);
         resultFileHBox.setSpacing(5);
         mainVBox.getChildren().add(resultFileHBox);
+        HBox specialTermHBox = new HBox(specialTermTextField);
+        specialTermHBox.setSpacing(5);
+        mainVBox.getChildren().add(specialTermHBox);
         singleQuerySearchHBox = new HBox(singleQueryTextField, searchQueryFromTextButton);
         singleQuerySearchHBox.setSpacing(5);
         mainVBox.getChildren().add(singleQuerySearchHBox);
@@ -250,13 +256,13 @@ public class GUI extends Application implements EventHandler<ActionEvent> {
             if (singleQueryTextField.getText().equals("") || singleQueryTextField.getText().equals("Insert your query here"))
                 AlertBox.display("", "Please write a query and try again!");
             else
-                ProgramStarter.runSingleQuery(singleQueryTextField.getText(), semanticallySimilarCheckBox.isSelected(), writeResultsToFileCheckBox.isSelected(), showEntitiesCheckBox.isSelected(), stemCheckBox.isSelected(), onlineSemanticCheckBox.isSelected(), resultFileTextField.getText(), resultFileName, showDateCheckBox.isSelected(), inputPath);
+                ProgramStarter.runSingleQuery(singleQueryTextField.getText(), semanticallySimilarCheckBox.isSelected(), writeResultsToFileCheckBox.isSelected(), showEntitiesCheckBox.isSelected(), stemCheckBox.isSelected(), onlineSemanticCheckBox.isSelected(), resultFileTextField.getText(), resultFileName, showDateCheckBox.isSelected(), inputPath, specialTermTextField.getText());
         }
         if (event.getSource() == searchUsingFileButton) {
             if (queriesFilePathTextFiled.getText().equals("") || queriesFilePathTextFiled.getText().equals("Or choose a file..."))
                 AlertBox.display("", "Please choose file and try again!");
             else
-                ProgramStarter.runQueriesFromFile(queriesFilePathTextFiled.getText(), semanticallySimilarCheckBox.isSelected(), writeResultsToFileCheckBox.isSelected(), showEntitiesCheckBox.isSelected(), stemCheckBox.isSelected(), onlineSemanticCheckBox.isSelected(), resultFileTextField.getText(), resultFileName, inputPath, showDateCheckBox.isSelected());
+                ProgramStarter.runQueriesFromFile(queriesFilePathTextFiled.getText(), semanticallySimilarCheckBox.isSelected(), writeResultsToFileCheckBox.isSelected(), showEntitiesCheckBox.isSelected(), stemCheckBox.isSelected(), onlineSemanticCheckBox.isSelected(), resultFileTextField.getText(), resultFileName, inputPath, showDateCheckBox.isSelected(), specialTermTextField.getText());
         }
     }
 


### PR DESCRIPTION
## Summary
- add new `UserSpecialTerm` class
- handle `UserSpecialTerm` in term builder
- track when a document contains the user special term
- boost ranking for documents with the special term
- add GUI input for the special term and pass it through search

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_6840b39afe04833286230dc30a28dea6